### PR TITLE
Fix import of matplotlib_toolkits

### DIFF
--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -360,7 +360,7 @@ which is the default for plotting matrix-type data (because this is where `[0:0]
 We can also add a colour bar to help describe the figure, with a little more code:
 
 ~~~
-import mpl_toolkits
+import mpl_toolkits.axes_grid1
 
 matplotlib.pyplot.figure()
 ax = matplotlib.pyplot.gca()


### PR DESCRIPTION
The matplotlib_toolkits module no longer list sub modules in __init__, so instead of `import matplotlib_toolkits` and `matplotlib_toolkits.axes_grid1.make_axes_locable` we have to `import matplotlib_toolkits.axes_grid1`

